### PR TITLE
IDE-4124 ParseResultsException occurs in scratchpad when 'uses' state…

### DIFF
--- a/gosu-test/src/test/gosu/gw/specContrib/statements/usesStatement/Errant_ImportsInGosuProgram.gsp
+++ b/gosu-test/src/test/gosu/gw/specContrib/statements/usesStatement/Errant_ImportsInGosuProgram.gsp
@@ -1,0 +1,6 @@
+uses java.math.BigDecimal
+
+print(BigDecimal.valueOf(1))
+
+uses java.math.BigInteger       //## issuekeys: MSG_UNEXPECTED_TOKEN
+uses java.math.BigInteger#ONE   //## issuekeys: MSG_UNEXPECTED_TOKEN


### PR DESCRIPTION
…ment is not the first